### PR TITLE
Updated README instructions to say `cdk deploy LambdaStack`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,12 @@
-# Welcome to your CDK TypeScript project
-
-This is a blank project for CDK development with TypeScript.
-
-The `cdk.json` file tells the CDK Toolkit how to execute your app.
-
-## Useful commands
-
-* `npm run build`   compile typescript to js
-* `npm run watch`   watch for changes and compile
-* `npm run test`    perform the jest unit tests
-* `npx cdk deploy`  deploy this stack to your default AWS account/region
-* `npx cdk diff`    compare deployed stack with current state
-* `npx cdk synth`   emits the synthesized CloudFormation template
+# ShopComp Backend
 
 ## How to use CDK to make Lambda functions
 
-* create folder in shopcomp-backend/bin/lib ex. createReceipt
-* create package.json and [lambdaName].mjs (refer to default package.json)
-* run npm install in the lambda function lib/[lambdaName]
-* create lambda function in [lambdaName].mjs
-* run 'npm run build' in shopcomp-backend directory
-* run 'cdk deploy', don't need 'cdk synth'
+* create folder in `shopcomp-backend/lib` with the name of the lambda function ex. createReceipt
+    * Use camelCase
+* create `package.json` and `[lambdaName].mjs` (refer to `lib/default/package.json`)
+* run `npm install` in the lambda function folder `lib/[lambdaName]`
+* write lambda function code in `[lambdaName].mjs`
+* run `npm run build` in `shopcomp-backend` directory
+* run `cdk deploy LambdaStack`, don't need `cdk synth`
 


### PR DESCRIPTION
See [PR #9](https://github.com/Software-Engineering-Kappa/shopcomp-backend/pull/9) for why this is needed