### PR TITLE
Modified `loginShopper` to return the user role

### DIFF
--- a/lib/login-shopper-stack.ts
+++ b/lib/login-shopper-stack.ts
@@ -33,12 +33,13 @@ export class LoginShopperStack extends cdk.Stack {
       timeout: Duration.seconds(3),
       environment: {
         USER_POOL_CLIENT_ID: process.env.USER_POOL_CLIENT_ID!,
+        USER_POOL_ID: process.env.USER_POOL_ID!,
       },
     })
 
     // Give login function permission to list user groups
     loginShopperFn.addToRolePolicy(new iam.PolicyStatement({
-      actions: ["congito-idp:AdminListGroupsForUser"],
+      actions: ["cognito-idp:AdminListGroupsForUser"],
       resources: ["*"],
     }))
 

--- a/lib/loginShopper/loginShopper.mjs
+++ b/lib/loginShopper/loginShopper.mjs
@@ -119,7 +119,7 @@ export const handler = async (event) => {
   try {
     const getGroupsParams = {
       Username: username,
-      UserPoolId: process.env.USER_POOL_CLIENT_ID,
+      UserPoolId: process.env.USER_POOL_ID,
     };
 
     // Send get group command


### PR DESCRIPTION
The `/shopper/login` endpoint now also returns a "role" which can be "shopper" or "admin"