### PR TITLE
Created helper CORS header function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 node_modules
 .env
 genai.txt
+gitreport-backend.txt
 
 # CDK asset staging directory
 .cdk.staging

--- a/lib/loginShopper/cors.mjs
+++ b/lib/loginShopper/cors.mjs
@@ -1,18 +1,19 @@
 const allowedOrigins = [
-  "http://localhost",    // local development
+  "http://localhost:3000",    // local development
+  "http://localhost:3001",    // local development
   "http://shop-comp-s3-bucket.s3-website-us-east-1.amazonaws.com"
-];
+]
 
 /**
  * Returns the CORS Access-Control headers for the given `event`
  */
 export function corsHeaders(event) {
   // Get origin of the request
-  const origin = event.headers.origin || event.headers.Origin;
+  const origin = event.headers.origin || event.headers.Origin
 
   const responseOrigin = allowedOrigins.includes(origin)
     ? origin
-    : allowedOrigins[0]; // fallback to localhost
+    : allowedOrigins[0] // fallback to localhost
 
   return {
     "Access-Control-Allow-Origin": responseOrigin,

--- a/lib/loginShopper/loginShopper.mjs
+++ b/lib/loginShopper/loginShopper.mjs
@@ -4,7 +4,7 @@ import {
   AdminListGroupsForUserCommand,
 } from "@aws-sdk/client-cognito-identity-provider"
 
-import { corsHeaders } from "./cors"
+import { corsHeaders } from "./cors.mjs"
 
 export const handler = async (event) => {
   const headers = {


### PR DESCRIPTION
I created a file `cors.mjs` which exports the `corsHeaders` function. You can copy this file to all of the lambda function folders, then import it and use it inside your lambda function code. I did this for `loginShopper` for you to see.

*Note: After this change, you may get an error when trying to test the endpoint from the API Gateway. The best way to test will be through the frontend or with curl*