### PR TITLE
Updated `loginShopper` to return access token in a cookie

### DIFF
--- a/lib/loginShopper/loginShopper.mjs
+++ b/lib/loginShopper/loginShopper.mjs
@@ -121,7 +121,8 @@ export const handler = async (event) => {
     `token=${loginResponse.AuthenticationResult.AccessToken}`,
     "HttpOnly",
     "Path=/",
-    "SameSite=Lax" 
+    "SameSite=None",
+    "Secure"
   ].filter(Boolean).join("; ");
   // cookie = "token=...; HttpOnly; Path=/; ..."
 


### PR DESCRIPTION
I am testing a more secure way to return the access token after logging in. Eventually, the token can be returned using the `Set-Cookie` header instead of returning in the body of the request. For now, I am returning the token in **both** the cookie and the body so that it will be compatible with our existing endpoints.