### PR TITLE
Added environment variables for deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,14 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      USER_POOL_CLIENT_ID: ${{ secrets.USER_POOL_CLIENT_ID }}
+      USER_POOL_ID: ${{ secrets.USER_POOL_ID }}
+      DB_HOST: ${{ secrets.DB_HOST }}
+      DB_NAME: ${{ secrets.DB_NAME }}
+      DB_PORT: ${{ secrets.DB_PORT }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+      DB_USER: ${{ secrets.DB_USER }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
These are needed for the lambda functions. We would normally load them from a `.env` file, but we don't check that into the repository.

After merging, try running the GitHub action. Make sure the environment variables are set inside the lambda functions. If it doesn't work, just disable the action.