### PR TITLE
Change id to receiptId to match other lambda functions and frontend

### DIFF
--- a/lib/addReceipts/addReceipts.mjs
+++ b/lib/addReceipts/addReceipts.mjs
@@ -82,7 +82,7 @@ export const handler = async (event) => {
             statusCode = 200;
             body = {
                 receipt: {
-                    id: receiptAdded.insertId,
+                    receiptId: receiptAdded.insertId,
                     chainId: requestBody.chainID,
                     storeId: receiptAdded.storeID,
                     date: isoDate.slice(0, 19).replace("T", " "),


### PR DESCRIPTION
I'm moving types to a separate file in the receipts page frontend so that they can be used by all functions in `boundary.tsx` but noticed that in addReceipts the `Receipt` interface's ID field name varies from `receiptId` (it being just `id` instead). `receiptId` is more clear so I am changing it so they both match.