### PR TITLE
Add receipt info to return of listItemsOnReceipt

### DIFF
--- a/lib/listItemsOnReceipt/listItemsOnReceipt.mjs
+++ b/lib/listItemsOnReceipt/listItemsOnReceipt.mjs
@@ -12,6 +12,29 @@ const getShopperId = (connection, receiptId) => {
     });
 };
 
+// get other receipt info
+const getReceiptInfo = (connection, receiptId) => {
+    return new Promise((resolve, reject) => {
+        const sqlQuery = `
+            SELECT
+                Chains.name as chainName,
+                Receipts.date as date
+            FROM
+                Receipts
+                INNER JOIN Stores
+                ON Receipts.storeID = Stores.ID
+                INNER JOIN Chains
+                ON Stores.chainID = Chains.ID
+            WHERE
+                Receipts.ID=?
+        `;
+        connection.query(sqlQuery, [receiptId], (error, results) => {
+            if (error) reject(error);
+            else resolve(results);
+        });
+    });
+};
+
 // Get purchases on given receiptId
 const getPurchases = (connection, receiptId) => {
     return new Promise((resolve, reject) => {
@@ -96,9 +119,23 @@ export const handler = async (event) => {
         // get purchases
         const purchases = await getPurchases(connection, receiptId);
 
+        // get other receipt info
+        const receiptInfo = await getReceiptInfo(connection, receiptId);
+
+        // getReceipt failed to find matching receipt, store, or chain
+        if (receiptInfo == undefined || receiptInfo == null || receiptInfo.length < 1) {
+            console.log("Receipt (info) not found");
+            statusCode = 400;
+            body = { "error": "Receipt (info) not found" };
+            return { statusCode, headers, body: JSON.stringify(body) };
+        }
+
         // success
         statusCode = 200;
         body = {
+            id: receiptId,
+            chainName: receiptInfo.chainName,
+            date: receiptInfo.date,
             items: purchases.map((p) => ({
                 purchaseId: p.purchaseId,
                 itemName: p.itemName,


### PR DESCRIPTION
Added more receipt information (`chainName` and `date`) to `listItemsOnReceipt` return to aid in frontend receipt retrieval (and eventual submission) process.
Closes #156