### PR TITLE
Fixed Report Options

### DIFF
--- a/lib/reportOptions/reportOptions.mjs
+++ b/lib/reportOptions/reportOptions.mjs
@@ -155,4 +155,3 @@ export const handler = async (event) => {
     }
   }
 }
-


### PR DESCRIPTION
- Replaced `execute` with `query`
- Fixed the issue where ShoppingListItems only referred to one Item by its item id in Items, however there could be multiple items (ex if I had bananas in my shopping list, it would only refer to 1 item when there could be multiple in different stores.) To fix this, I joined ShoppingListItems and Items by the name instead of Id 